### PR TITLE
Fix parallel post-build copy race on native DLLs

### DIFF
--- a/SAM_Topologic/SAM.Analytical.Topologic/SAM.Analytical.Topologic.csproj
+++ b/SAM_Topologic/SAM.Analytical.Topologic/SAM.Analytical.Topologic.csproj
@@ -51,8 +51,8 @@
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <PropertyGroup>
-    <PostBuildEvent>Copy /Y "$(SolutionDir)references\TopologicCore.dll" "$(SolutionDir)build\TopologicCore.dll"
-Copy /Y "$(SolutionDir)references\TK*.dll" "$(SolutionDir)build\TK*.dll"</PostBuildEvent>
+    <PostBuildEvent>robocopy "$(SolutionDir)references" "$(SolutionDir)build" TopologicCore.dll /R:5 /W:2 &amp; IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0
+robocopy "$(SolutionDir)references" "$(SolutionDir)build" TK*.dll /R:5 /W:2 &amp; IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0</PostBuildEvent>
     <AssemblyTitle>SAM_Topologic</AssemblyTitle>
     <Product>SAM_Topologic</Product>
     <Copyright>Copyright ©  2019</Copyright>

--- a/SAM_Topologic/SAM.Core.Topologic/SAM.Core.Topologic.csproj
+++ b/SAM_Topologic/SAM.Core.Topologic/SAM.Core.Topologic.csproj
@@ -35,9 +35,9 @@
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
   <PropertyGroup>
-    <PostBuildEvent>Copy /Y "$(SolutionDir)references\TopologicCore.dll" "$(SolutionDir)build\TopologicCore.dll"
-Copy /Y "$(SolutionDir)references\TK*.dll" "$(SolutionDir)build\TK*.dll"
-Copy /Y "$(SolutionDir)references\tbb*.dll" "$(SolutionDir)build\tbb*.dll"</PostBuildEvent>
+    <PostBuildEvent>robocopy "$(SolutionDir)references" "$(SolutionDir)build" TopologicCore.dll /R:5 /W:2 &amp; IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0
+robocopy "$(SolutionDir)references" "$(SolutionDir)build" TK*.dll /R:5 /W:2 &amp; IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0
+robocopy "$(SolutionDir)references" "$(SolutionDir)build" tbb*.dll /R:5 /W:2 &amp; IF %ERRORLEVEL% LEQ 7 SET ERRORLEVEL=0</PostBuildEvent>
     <AssemblyTitle>SAM_Topologic</AssemblyTitle>
     <Product>SAM_Topologic</Product>
     <Copyright>Copyright (c) 2020-2026 Michal Dengusiak &amp; Jakub Ziolkowski and contributors</Copyright>


### PR DESCRIPTION
SAM.Analytical.Topologic and SAM.Core.Topologic used plain `Copy /Y` to copy TopologicCore/TK*/tbb* DLLs from references\ into build\. When the solution builds in parallel (/m), these copies race against each other and SAM.Geometry.Topologic for the same target files, intermittently failing with a file lock and breaking the build.

Switch both to robocopy with retry (/R:5 /W:2) and tolerate exit codes <=7, matching the pattern SAM.Geometry.Topologic already uses. Verified clean across repeated parallel rebuilds.

### Summary
What is delivered and why (1–3 sentences).

### Validation
How to verify or test the change.
